### PR TITLE
validate Supabase environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 This app was created automatically by Base44.
 It's a Vite+React app that communicates with the Base44 API.
 
+## Environment variables
+
+The application expects Supabase credentials to be provided at runtime:
+
+- `VITE_SUPABASE_URL` (or `NEXT_PUBLIC_SUPABASE_URL`)
+- `VITE_SUPABASE_ANON_KEY` (or `NEXT_PUBLIC_SUPABASE_ANON_KEY`)
+
+These variables must be set in your environment before starting the app.
+
 ## Running the app
 
 ```bash

--- a/src/api/supabaseClient.ts
+++ b/src/api/supabaseClient.ts
@@ -1,28 +1,41 @@
 import { createClient } from '@supabase/supabase-js';
 
-// Supabase credentials - using Vite environment variables
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 
-                   import.meta.env.NEXT_PUBLIC_SUPABASE_URL || 
-                   'https://uyahditchuyudbpphfry.supabase.co';
+// Retrieve Supabase credentials from environment variables
+const supabaseUrl =
+  import.meta.env.VITE_SUPABASE_URL ?? import.meta.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ??
+  import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 
-                       import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 
-                       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InV5YWhkaXRjaHV5dWRicHBoZnJ5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQ4OTE2NDEsImV4cCI6MjA3MDQ2NzY0MX0.WDV9zfZXDvMPzF7KbP3rH-tO7uswlfVobOz4HI4UmkA';
+if (!supabaseUrl || !supabaseAnonKey) {
+  const missingVars: string[] = [];
+  if (!supabaseUrl) {
+    missingVars.push('VITE_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL');
+  }
+  if (!supabaseAnonKey) {
+    missingVars.push(
+      'VITE_SUPABASE_ANON_KEY or NEXT_PUBLIC_SUPABASE_ANON_KEY',
+    );
+  }
+  const message = `Missing required environment variables: ${missingVars.join(', ')}`;
+  console.error(message);
+  throw new Error(message);
+}
 
 console.log('Supabase Client Configuration:', {
   supabaseUrl,
-  supabaseAnonKey: supabaseAnonKey ? `${supabaseAnonKey.substring(0, 20)}...` : 'NOT SET',
+  supabaseAnonKey: `${supabaseAnonKey.substring(0, 20)}...`,
   hasViteUrl: !!import.meta.env.VITE_SUPABASE_URL,
   hasNextPublicUrl: !!import.meta.env.NEXT_PUBLIC_SUPABASE_URL,
   hasViteKey: !!import.meta.env.VITE_SUPABASE_ANON_KEY,
-  hasNextPublicKey: !!import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  hasNextPublicKey: !!import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
 });
 
 // Create Supabase client
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 // Test connection
-supabase.auth.getSession().then(({ data, error }) => {
+supabase.auth.getSession().then(({ error }) => {
   if (error) {
     console.error('Supabase connection test failed:', error);
   } else {
@@ -32,3 +45,4 @@ supabase.auth.getSession().then(({ data, error }) => {
 
 // Export for backward compatibility
 export const base44 = supabase;
+


### PR DESCRIPTION
## Summary
- validate Supabase credentials at runtime and fail if missing
- document required Supabase environment variables

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: linting errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a031e04bdc83259571e2676aef3295