### PR TITLE
refactor: centralize development logger

### DIFF
--- a/src/api/supabaseClient.ts
+++ b/src/api/supabaseClient.ts
@@ -1,21 +1,23 @@
 import { createClient } from '@supabase/supabase-js';
+import { devLogger } from '../utils';
 
 // Supabase credentials - using Vite environment variables
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 
                    import.meta.env.NEXT_PUBLIC_SUPABASE_URL || 
                    'https://uyahditchuyudbpphfry.supabase.co';
 
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 
-                       import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 
-                       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InV5YWhkaXRjaHV5dWRicHBoZnJ5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQ4OTE2NDEsImV4cCI6MjA3MDQ2NzY0MX0.WDV9zfZXDvMPzF7KbP3rH-tO7uswlfVobOz4HI4UmkA';
+const supabaseAnonKey =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ||
+  import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InV5YWhkaXRjaHV5dWRicHBoZnJ5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQ4OTE2NDEsImV4cCI6MjA3MDQ2NzY0MX0.WDV9zfZXDvMPzF7KbP3rH-tO7uswlfVobOz4HI4UmkA';
 
-console.log('Supabase Client Configuration:', {
+devLogger.info('Supabase Client Configuration', {
   supabaseUrl,
   supabaseAnonKey: supabaseAnonKey ? `${supabaseAnonKey.substring(0, 20)}...` : 'NOT SET',
-  hasViteUrl: !!import.meta.env.VITE_SUPABASE_URL,
-  hasNextPublicUrl: !!import.meta.env.NEXT_PUBLIC_SUPABASE_URL,
-  hasViteKey: !!import.meta.env.VITE_SUPABASE_ANON_KEY,
-  hasNextPublicKey: !!import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  hasViteUrl: Boolean(import.meta.env.VITE_SUPABASE_URL),
+  hasNextPublicUrl: Boolean(import.meta.env.NEXT_PUBLIC_SUPABASE_URL),
+  hasViteKey: Boolean(import.meta.env.VITE_SUPABASE_ANON_KEY),
+  hasNextPublicKey: Boolean(import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY)
 });
 
 // Create Supabase client
@@ -24,9 +26,9 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 // Test connection
 supabase.auth.getSession().then(({ data, error }) => {
   if (error) {
-    console.error('Supabase connection test failed:', error);
+    devLogger.error('Supabase connection test failed:', error);
   } else {
-    console.log('Supabase connection test successful');
+    devLogger.info('Supabase connection test successful');
   }
 });
 

--- a/src/utils/devLogger.ts
+++ b/src/utils/devLogger.ts
@@ -1,0 +1,13 @@
+export const devLogger = {
+  info: (message: string, ...args: unknown[]) => {
+    if (import.meta.env.DEV) {
+      console.log(message, ...args);
+    }
+  },
+  error: (message: string, ...args: unknown[]) => {
+    if (import.meta.env.DEV) {
+      console.error(message, ...args);
+    }
+  }
+};
+

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,5 @@
-
-
+export * from './devLogger';
 
 export function createPageUrl(pageName: string) {
-    return '/' + pageName;
+  return '/' + pageName;
 }


### PR DESCRIPTION
## Summary
- extract dev-only logger into `src/utils/devLogger.ts`
- consume shared `devLogger` in Supabase client for sanitized config diagnostics

## Testing
- ❌ `npm test` (missing script: test)
- ❌ `npm run lint` (183 errors, 62 warnings)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a03344feac8325ba954fe2adcf667a