### PR TITLE
refactor: type safety for verification and bank details components

### DIFF
--- a/src/components/dashboard/VerificationStatus.tsx
+++ b/src/components/dashboard/VerificationStatus.tsx
@@ -2,20 +2,31 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
-import { 
-  CheckCircle, 
-  AlertTriangle, 
-  Clock, 
-  Shield, 
-  FileText, 
+import {
+  CheckCircle,
+  AlertTriangle,
+  Clock,
+  Shield,
+  FileText,
   Building2,
   User,
   CreditCard
 } from 'lucide-react';
 
+interface Dealer {
+  business_name?: string;
+  kyb_status?: string;
+  payment_method_verified?: boolean;
+  background_check_status?: string;
+}
+
+interface DashboardUser {
+  email_verified?: boolean;
+}
+
 interface VerificationStatusProps {
-  dealer: any;
-  user: any;
+  dealer: Dealer;
+  user: DashboardUser;
 }
 
 export default function VerificationStatus({ dealer, user }: VerificationStatusProps) {

--- a/src/components/onboarding/steps/BankDetailsStep.tsx
+++ b/src/components/onboarding/steps/BankDetailsStep.tsx
@@ -7,16 +7,39 @@ import { UploadFile } from '@/api/integrations';
 import { DealerDocument } from '@/api/entities';
 import { toast } from 'sonner';
 
+interface UploadedCheque {
+  fileName: string;
+  fileSize: number;
+  fileType: string;
+  uploadedAt: string;
+  url: string;
+  storagePath: string;
+  dbRecord: unknown;
+}
+
+interface BankDetails {
+  accountHolderName: string;
+  accountNumber: string;
+  ifscCode: string;
+  bankName: string;
+  cancelledCheque: UploadedCheque | null;
+}
+
+interface OnboardingData {
+  bankDetails?: BankDetails;
+  [key: string]: unknown;
+}
+
 interface BankDetailsStepProps {
-  data: any;
-  updateData: (data: any) => void;
-  onNext: (data: any) => void;
+  data: OnboardingData;
+  updateData: (data: OnboardingData) => void;
+  onNext: (data: BankDetails) => void;
   onBack: () => void;
   onSkip: () => void;
   isSaving: boolean;
   currentStep: number;
   totalSteps: number;
-  dealer?: any; // Add dealer prop to access registration data
+  dealer?: { id?: string };
 }
 
 const BankDetailsStep: React.FC<BankDetailsStepProps> = ({
@@ -27,7 +50,7 @@ const BankDetailsStep: React.FC<BankDetailsStepProps> = ({
   isSaving,
   dealer
 }) => {
-  const [bankData, setBankData] = React.useState(data.bankDetails || {
+  const [bankData, setBankData] = React.useState<BankDetails>(data.bankDetails || {
     accountHolderName: '',
     accountNumber: '',
     ifscCode: '',
@@ -42,7 +65,7 @@ const BankDetailsStep: React.FC<BankDetailsStepProps> = ({
     }
   }, [data.bankDetails]);
 
-  const handleInputChange = (field: string, value: string) => {
+  const handleInputChange = (field: keyof BankDetails, value: string) => {
     const newBankData = { ...bankData, [field]: value };
     setBankData(newBankData);
     updateData({ ...data, bankDetails: newBankData });
@@ -113,9 +136,10 @@ const BankDetailsStep: React.FC<BankDetailsStepProps> = ({
       } else {
         throw new Error("Upload failed to return a URL.");
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Upload failed:', error);
-      toast.error(`Failed to upload ${file.name}: ${error.message}`);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      toast.error(`Failed to upload ${file.name}: ${message}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- replace `any` props with typed interfaces in VerificationStatus
- add detailed interfaces for BankDetailsStep props and state

## Testing
- `npm run lint` *(fails: Unexpected any errors in unrelated files)*
- `npx eslint src/components/dashboard/VerificationStatus.tsx src/components/onboarding/steps/BankDetailsStep.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a0425529c88325b8671a007c9350ce